### PR TITLE
Layer 1 writing convention

### DIFF
--- a/content/guide/etna-changes.mdx
+++ b/content/guide/etna-changes.mdx
@@ -3,15 +3,15 @@ title: What to Expect After the Etna Upgrade
 description: This guide outlines the operational impact on existing network participants expected from the activation of the AvalancheGo "Etna" upgrade.
 date: 2024-08-23
 authors: [meagfitzgerald]
-topics: [Avalanche Network Upgrade, Etna Upgrade, Validators, Layer1s, L1s]
+topics: [Avalanche Network Upgrade, Etna Upgrade, Validators, Layer 1, L1]
 ---
 
 This guide outlines the operational impact on existing network participants expected from the activation of the AvalancheGo "Etna" upgrade.
 
 ## Vocabulary, New and Old
 
-- **L1**: An Avalanche Layer-1 Network, previously called an Avalanche “Subnet”. An L1 is a sovereign network that has its own dynamic set of validators, rules for network participation, and defines its own validator rewards incentives.
-- **L1-only-validator**: A validator that only validates an Avalanche layer1 blockchain (Previously called a Subnet-only-validator in ACP-77). These validators are not required to stake 2000 AVAX, or validate the Avalanche Primary Network. They instead pay a continuous fee in order to participate in L1 validation.
+- **L1**: An Avalanche Layer 1 Network, previously called an Avalanche “Subnet”. An L1 is a sovereign network that has its own dynamic set of validators, rules for network participation, and defines its own validator rewards incentives.
+- **L1-only-validator**: A validator that only validates an Avalanche layer 1 blockchain (Previously called a Subnet-only-validator in ACP-77). These validators are not required to stake 2000 AVAX, or validate the Avalanche Primary Network. They instead pay a continuous fee in order to participate in L1 validation.
 - **ACP-77**: The Avalanche Community Proposal that outlines a new framework for creating low-cost, independent blockchains that can _easily_ interoperate with each other. You can read the full proposal [here](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/77-reinventing-subnets/README.md).
 - **The Primary Network**: The Avalanche X,P, and C-Chains, a.k.a. the 3 primary blockchains that most validators currently sync on Avalanche Mainnet.
 
@@ -19,7 +19,7 @@ This guide outlines the operational impact on existing network participants expe
 
 ### Subnets Are Now Called L1s
 
-Avalanche Subnets are being rebranded as Avalanche L1s. Unlike layer2 blockchains, layer 1 blockchains operate independently without relying on other systems for their core functions.
+Avalanche Subnets are being rebranded as Avalanche L1s. Unlike layer 2 blockchains, layer 1 blockchains operate independently without relying on other systems for their core functions.
 They manage their own consensus mechanisms, transaction processing, and security protocols directly within their own networks.
 
 Subnets have always operated this way, scaling Avalanche's network _horizontally_ instead of compounding dependencies by requiring chains to roll down to other networks.


### PR DESCRIPTION
nits to correct usage of "layer 1" and "layer 2". Corrected according to usage in The Block and layer 2 protocols' dev docs.