### PR TITLE
71 signature schemes reimplement demo

### DIFF
--- a/components/multiSignatureSchemes.tsx
+++ b/components/multiSignatureSchemes.tsx
@@ -1,6 +1,11 @@
 "use client";
 import React, { useState } from 'react';
 const bls = require("@noble/bls12-381");
+import {
+    CodeBlock, Pre
+  } from 'fumadocs-ui/components/codeblock';
+import { buttonVariants } from './ui/button';
+import { Input } from './ui/input';
 
 const bufferToHex = (buffer: ArrayBufferLike): string => {
     return [...new Uint8Array(buffer)]
@@ -44,71 +49,33 @@ export const GenerateKeysButton: React.FC = () => {
     };
 
     return (
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-            <div style={{ textAlign: 'center', marginRight: '20px' }}>
-                <button
-                    className="btn btn-primary"
-                    style={{
-                        backgroundColor: 'red',
-                        color: 'white',
-                        padding: '10px 20px',
-                        borderRadius: '5px',
-                        margin: '10px'
-                    }}
-                    onClick={generateKeys1}
-                >
-                    Generate Keys
+        <div>
+            <div style={{ textAlign: 'center', marginRight: '20px', marginBottom: '20px' }}>
+                <button className={buttonVariants()} onClick={generateKeys1}>
+                    Generate First Keypair
                 </button>
 
-                <div style={{ padding: '10px' }}>
-                    <p>🗝️Private Key: {privKey1?.substring(0, 6)}...</p>
-                    <button
-                        onClick={() => copyToClipboard(privKey1 ? String(privKey1) : '')}
-                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
-                    >
-                        Copy Private Key
-                    </button>
-                    <p style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>🔑Public Key: {pubKey1?.substring(0, 6)}...</p>
-                    <button
-                        onClick={() => copyToClipboard(pubKey1 ? String(pubKey1) : '')}
-                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
-                    >
-                        Copy Public Key
-                    </button>
-                </div>
+                {privKey1 && <CodeBlock title="🗝️ Private Key" lang="bash" allowCopy={true}>
+                    <Pre>{privKey1}</Pre>
+                </CodeBlock>}
+
+                {pubKey1 && <CodeBlock title="🔑 Public Key:" lang="bash" allowCopy={true}>
+                    <Pre>{pubKey1}</Pre>
+                </CodeBlock>}
             </div>
 
             <div style={{ textAlign: 'center' }}>
-                <button
-                    className="btn btn-primary"
-                    style={{
-                        backgroundColor: 'red',
-                        color: 'white',
-                        padding: '10px 20px',
-                        borderRadius: '5px',
-                        margin: '10px'
-                    }}
-                    onClick={generateKeys2}
-                >
-                    Generate Keys
+                <button className={buttonVariants()} onClick={generateKeys2}>
+                    Generate Second Keypair
                 </button>
 
-                <div style={{ padding: '10px' }}>
-                    <p>🗝️Private Key: {privKey2?.substring(0, 6)}...</p>
-                    <button
-                        onClick={() => copyToClipboard(privKey2 ? String(privKey2) : '')}
-                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
-                    >
-                        Copy Private Key
-                    </button>
-                    <p style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>🔑Public Key: {pubKey2?.substring(0, 6)}...</p>
-                    <button
-                        onClick={() => copyToClipboard(pubKey2 ? String(pubKey2) : '')}
-                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
-                    >
-                        Copy Public Key
-                    </button>
-                </div>
+                {privKey2 && <CodeBlock title="🗝️ Private Key" lang="bash" allowCopy={true}>
+                    <Pre>{privKey2}</Pre>
+                </CodeBlock>}
+
+                {pubKey2 && <CodeBlock title="🔑 Public Key:" lang="bash" allowCopy={true}>
+                    <Pre>{pubKey2}</Pre>
+                </CodeBlock>}
             </div>
         </div>
     );
@@ -146,46 +113,40 @@ export const SignMessageButton: React.FC = () => {
         <div style={{ display: 'flex', justifyContent: 'center' }}>
             <div style={{ textAlign: 'center', marginRight: '20px' }}>
                 <p>🗝️Private Key</p>
-                <input type="text" id="privatekey1" placeholder="Enter private key to sign message with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPrivKey1(e.target.value)} />
+                <Input id="privatekey1" placeholder="Enter private key to sign message with" onChange={(e) => setPrivKey1(e.target.value)} />
                 <br />
                 <p>📝Message</p>
-                <input type="text" id="message1" placeholder="Enter message to sign" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage1(e.target.value)} />
+                <Input id="message1" placeholder="Enter message to sign" onChange={(e) => setMessage1(e.target.value)} />
 
-                <button
-                    className="btn btn-primary"
-                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
-                    onClick={signMessage1}
-                >
+                <button className={buttonVariants()} onClick={signMessage1}>
                     Sign Message
                 </button>
 
                 {showSignature1 && (
                     <>
-                        <p>Signature 1:</p>
-                        <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{signature1}</p>
+                         {signature1 && <CodeBlock title="🔏 Signature:" lang="bash" allowCopy={true} style={{ maxWidth: '350px', margin: '0 auto' }}>
+                            <Pre>{signature1}</Pre>
+                        </CodeBlock>}
                     </>
                 )}
             </div>
 
             <div style={{ textAlign: 'center' }}>
                 <p>🗝️Private Key</p>
-                <input type="text" id="privatekey2" placeholder="Enter private key to sign message with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPrivKey2(e.target.value)} />
+                <Input id="privatekey2" placeholder="Enter private key to sign message with" onChange={(e) => setPrivKey2(e.target.value)} />
                 <br />
                 <p>📝Message</p>
-                <input type="text" id="message2" placeholder="Enter message to sign" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage2(e.target.value)} />
+                <Input id="message2" placeholder="Enter message to sign" onChange={(e) => setMessage2(e.target.value)} />
 
-                <button
-                    className="btn btn-primary"
-                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
-                    onClick={signMessage2}
-                >
+                <button className={buttonVariants()} onClick={signMessage2}>
                     Sign Message
                 </button>
 
                 {showSignature2 && (
                     <>
-                        <p>Signature 2:</p>
-                        <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{signature2}</p>
+                        {signature2 && <CodeBlock title="🔏 Signature:" lang="bash" allowCopy={true} style={{ maxWidth: '350px', margin: '0 auto' }}>
+                            <Pre>{signature2}</Pre>
+                        </CodeBlock>}
                     </>
                 )}
             </div>
@@ -202,42 +163,31 @@ export const AggregateSignaturesButton: React.FC = () => {
 
     return (
         <div style={{ textAlign: 'center' }}>
-            <input
-                type="text"
+            <Input
                 id="signature1"
                 placeholder="Enter signature 1"
-                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
                 onChange={(e) => setSignature1(e.target.value)}
             />
-            <input
-                type="text"
+            <Input
                 id="signature2"
                 placeholder="Enter signature 2"
-                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
                 onChange={(e) => setSignature2(e.target.value)}
             />
-            <button
-                style={{
-                    backgroundColor: 'red',
-                    color: 'white',
-                    padding: '10px 20px',
-                    borderRadius: '5px',
-                    border: 'none',
-                    marginRight: '5px',
-                }}
-                onClick={() => {
-                    if (signature1 && signature2) {
-                        setAggregatedSignature(bufferToHex(bls.aggregateSignatures([signature1, signature2])));
-                        setShowAggregatedSignature(true);
-                    }
-                }}>
+            <button className={buttonVariants()} onClick={() => {
+                 if (signature1 && signature2) {
+                    setAggregatedSignature(bufferToHex(bls.aggregateSignatures([signature1, signature2])));
+                    setShowAggregatedSignature(true);
+                }
+            }}>
                 Aggregate Signatures
             </button>
+            
 
             {showAggregatedSignature && (
                 <>
-                    <p>Aggregated Signature:</p>
-                    <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{aggregatedSignature}</p>
+                    {aggregatedSignature && <CodeBlock title="🔏 Signature:" lang="bash" allowCopy={true}>
+                            <Pre>{aggregatedSignature}</Pre>
+                    </CodeBlock>}
                 </>
             )}
         </div>
@@ -252,44 +202,33 @@ export const AggregatePublicKeysButton: React.FC = () => {
 
     return(
         <div style={{ textAlign: 'center' }}>
-            <input
-                type="text"
+            <Input
                 id="pubkey1"
                 placeholder="Enter public key 1"
-                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
                 onChange={(e) => setPubKey1(e.target.value)}
 
             />
-            <input
-                type="text"
+            <Input
                 id="pubkey2"
                 placeholder="Enter public key 2"
-                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
                 onChange={(e) => setPubKey2(e.target.value)}
 
             />
-            <button
-                style={{
-                    backgroundColor: 'red',
-                    color: 'white',
-                    padding: '10px 20px',
-                    borderRadius: '5px',
-                    border: 'none',
-                    marginRight: '5px',
-                }}
-                onClick={() => {
-                    if (pubKey1 && pubKey2) {
+
+                <button className={buttonVariants()} onClick={() => {
+                     if (pubKey1 && pubKey2) {
                         setAggregatedPubKey(bufferToHex(bls.aggregatePublicKeys([pubKey1, pubKey2])));
                         setShowAggregatedPubKey(true);
                     }
                 }}>
                 Aggregate Public Keys
-            </button>
+                </button>
 
             {showAggregatedPubKey && (
                 <>
-                    <p>Aggregated Public Key:</p>
-                    <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{aggregatedPubKey}</p>
+                    {aggregatedPubKey && <CodeBlock title="🔑 Public Key:" lang="bash" allowCopy={true}>
+                            <Pre>{aggregatedPubKey}</Pre>
+                    </CodeBlock>}
                 </>
             )}
         </div>
@@ -304,38 +243,32 @@ export const VerifyAggregateSignatureButton: React.FC = () => {
     return(
         <div style={{ textAlign: 'center' }}>
         <p>🔑Aggregated Public Key</p>
-        <input type="text" id="publickey" placeholder="Enter aggregated public key to verify with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPubKey(e.target.value)}/>
+        <Input id="publickey" placeholder="Enter aggregated public key to verify with" onChange={(e) => setPubKey(e.target.value)}/>
         <br />
         <p>🔏Aggregated Signature</p>
-        <input type="text" id="signature" placeholder="Enter aggregated signature to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setSignature(e.target.value)}/>
+        <Input id="signature" placeholder="Enter aggregated signature to verify" onChange={(e) => setSignature(e.target.value)}/>
         <br />
         <p>📝Message</p>
-        <input type="text" id="message" placeholder="Enter message to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage(e.target.value)}/>
+        <Input id="message" placeholder="Enter message to verify" onChange={(e) => setMessage(e.target.value)}/>
         <br />
-        <button
-            className="btn btn-primary"
-            style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
-            onClick={() => {
-                if (signature && pubKey && message) {
-                    checkSig(signature, pubKey, message).then((res) => {
-                        if (res) {
-                            setSignatureResult(res);
-                        } else {
-                            setSignatureResult(false);
-                        }
-                    });
-                }
-            }}
-        >
-            Verify
+
+        <button className={buttonVariants()} onClick={() => {
+                     if (signature && pubKey && message) {
+                        checkSig(signature, pubKey, message).then((res) => {
+                            if (res) {
+                                setSignatureResult(res);
+                            } else {
+                                setSignatureResult(false);
+                            }
+                        });
+                    }
+                }}>
+                Verify        
         </button>
 
         {signatureResult !== null && (
-            <>
-                <p>Signature Result:</p>
-                <p>{signatureResult ? 'Aggregated Signature valid! The Aggregated Signature of the Message was created with the Secret Key that corresponds to the provided Public Key.' : 'Signature invalid! Double check your inputs are correct'}</p>
-            </>
-        )}
+                <p>{signatureResult ? '✅ Signature is valid!' : '❌ Signature is invalid!'}</p>
+            )}
     </div>
     )
 }

--- a/components/multiSignatureSchemes.tsx
+++ b/components/multiSignatureSchemes.tsx
@@ -1,0 +1,343 @@
+"use client";
+import React, { useState } from 'react';
+const bls = require("@noble/bls12-381");
+
+const bufferToHex = (buffer: ArrayBufferLike): string => {
+    return [...new Uint8Array(buffer)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+}
+
+const checkSig = async (signature: string, publicKey: string, message: string) => {
+    let res = await bls.verify(signature, new TextEncoder().encode(message), publicKey);
+    return res
+}
+
+
+export const GenerateKeysButton: React.FC = () => {
+    const [privKey1, setPrivKey1] = useState<string | null>(null);
+    const [pubKey1, setPubKey1] = useState<string | null>(null);
+
+    const [privKey2, setPrivKey2] = useState<string | null>(null);
+    const [pubKey2, setPubKey2] = useState<string | null>(null);
+
+    const generateKeys1 = () => {
+        const privKey = new Uint8Array(32);
+        crypto.getRandomValues(privKey);
+        const pubKey = bufferToHex(bls.getPublicKey(privKey));
+        setPrivKey1(bufferToHex(privKey));
+        setPubKey1(pubKey);
+        return { privKey, pubKey };
+    };
+
+    const generateKeys2 = () => {
+        const privKey = new Uint8Array(32);
+        crypto.getRandomValues(privKey);
+        const pubKey = bufferToHex(bls.getPublicKey(privKey));
+        setPrivKey2(bufferToHex(privKey));
+        setPubKey2(pubKey);
+        return { privKey, pubKey };
+    };
+
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text);
+    };
+
+    return (
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ textAlign: 'center', marginRight: '20px' }}>
+                <button
+                    className="btn btn-primary"
+                    style={{
+                        backgroundColor: 'red',
+                        color: 'white',
+                        padding: '10px 20px',
+                        borderRadius: '5px',
+                        margin: '10px'
+                    }}
+                    onClick={generateKeys1}
+                >
+                    Generate Keys
+                </button>
+
+                <div style={{ padding: '10px' }}>
+                    <p>🗝️Private Key: {privKey1?.substring(0, 6)}...</p>
+                    <button
+                        onClick={() => copyToClipboard(privKey1 ? String(privKey1) : '')}
+                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
+                    >
+                        Copy Private Key
+                    </button>
+                    <p style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>🔑Public Key: {pubKey1?.substring(0, 6)}...</p>
+                    <button
+                        onClick={() => copyToClipboard(pubKey1 ? String(pubKey1) : '')}
+                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
+                    >
+                        Copy Public Key
+                    </button>
+                </div>
+            </div>
+
+            <div style={{ textAlign: 'center' }}>
+                <button
+                    className="btn btn-primary"
+                    style={{
+                        backgroundColor: 'red',
+                        color: 'white',
+                        padding: '10px 20px',
+                        borderRadius: '5px',
+                        margin: '10px'
+                    }}
+                    onClick={generateKeys2}
+                >
+                    Generate Keys
+                </button>
+
+                <div style={{ padding: '10px' }}>
+                    <p>🗝️Private Key: {privKey2?.substring(0, 6)}...</p>
+                    <button
+                        onClick={() => copyToClipboard(privKey2 ? String(privKey2) : '')}
+                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
+                    >
+                        Copy Private Key
+                    </button>
+                    <p style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>🔑Public Key: {pubKey2?.substring(0, 6)}...</p>
+                    <button
+                        onClick={() => copyToClipboard(pubKey2 ? String(pubKey2) : '')}
+                        style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
+                    >
+                        Copy Public Key
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export const SignMessageButton: React.FC = () => {
+    const [privKey1, setPrivKey1] = useState<string | null>(null);
+    const [message1, setMessage1] = useState<string | null>(null);
+    const [signature1, setSignature1] = useState<string | null>(null);
+
+    const [privKey2, setPrivKey2] = useState<string | null>(null);
+    const [message2, setMessage2] = useState<string | null>(null);
+    const [signature2, setSignature2] = useState<string | null>(null);
+
+    const [showSignature1, setShowSignature1] = useState(false);
+    const [showSignature2, setShowSignature2] = useState(false);
+
+    const signMessage1 = async () => {
+        if (!privKey1 || !message1) {
+            return;
+        }
+        setSignature1(bufferToHex(await bls.sign(new TextEncoder().encode(message1), privKey1)));
+        setShowSignature1(true);
+    }
+
+    const signMessage2 = async () => {
+        if (!privKey2 || !message2) {
+            return;
+        }
+        setSignature2(bufferToHex(await bls.sign(new TextEncoder().encode(message2), privKey2)));
+        setShowSignature2(true);
+    }
+
+    return (
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ textAlign: 'center', marginRight: '20px' }}>
+                <p>🗝️Private Key</p>
+                <input type="text" id="privatekey1" placeholder="Enter private key to sign message with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPrivKey1(e.target.value)} />
+                <br />
+                <p>📝Message</p>
+                <input type="text" id="message1" placeholder="Enter message to sign" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage1(e.target.value)} />
+
+                <button
+                    className="btn btn-primary"
+                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
+                    onClick={signMessage1}
+                >
+                    Sign Message
+                </button>
+
+                {showSignature1 && (
+                    <>
+                        <p>Signature 1:</p>
+                        <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{signature1}</p>
+                    </>
+                )}
+            </div>
+
+            <div style={{ textAlign: 'center' }}>
+                <p>🗝️Private Key</p>
+                <input type="text" id="privatekey2" placeholder="Enter private key to sign message with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPrivKey2(e.target.value)} />
+                <br />
+                <p>📝Message</p>
+                <input type="text" id="message2" placeholder="Enter message to sign" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage2(e.target.value)} />
+
+                <button
+                    className="btn btn-primary"
+                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
+                    onClick={signMessage2}
+                >
+                    Sign Message
+                </button>
+
+                {showSignature2 && (
+                    <>
+                        <p>Signature 2:</p>
+                        <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{signature2}</p>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export const AggregateSignaturesButton: React.FC = () => {
+
+    const [signature1, setSignature1] = useState<string | null>(null);
+    const [signature2, setSignature2] = useState<string | null>(null);
+    const [aggregatedSignature, setAggregatedSignature] = useState<string | null>(null);
+    const [showAggregatedSignature, setShowAggregatedSignature] = useState(false);
+
+    return (
+        <div style={{ textAlign: 'center' }}>
+            <input
+                type="text"
+                id="signature1"
+                placeholder="Enter signature 1"
+                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
+                onChange={(e) => setSignature1(e.target.value)}
+            />
+            <input
+                type="text"
+                id="signature2"
+                placeholder="Enter signature 2"
+                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
+                onChange={(e) => setSignature2(e.target.value)}
+            />
+            <button
+                style={{
+                    backgroundColor: 'red',
+                    color: 'white',
+                    padding: '10px 20px',
+                    borderRadius: '5px',
+                    border: 'none',
+                    marginRight: '5px',
+                }}
+                onClick={() => {
+                    if (signature1 && signature2) {
+                        setAggregatedSignature(bufferToHex(bls.aggregateSignatures([signature1, signature2])));
+                        setShowAggregatedSignature(true);
+                    }
+                }}>
+                Aggregate Signatures
+            </button>
+
+            {showAggregatedSignature && (
+                <>
+                    <p>Aggregated Signature:</p>
+                    <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{aggregatedSignature}</p>
+                </>
+            )}
+        </div>
+    );
+}
+export const AggregatePublicKeysButton: React.FC = () => {
+
+    const [pubKey1, setPubKey1] = useState<string | null>(null);
+    const [pubKey2, setPubKey2] = useState<string | null>(null);
+    const [aggregatedPubKey, setAggregatedPubKey] = useState<string | null>(null);
+    const [showAggregatedPubKey, setShowAggregatedPubKey] = useState(false);
+
+    return(
+        <div style={{ textAlign: 'center' }}>
+            <input
+                type="text"
+                id="pubkey1"
+                placeholder="Enter public key 1"
+                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
+                onChange={(e) => setPubKey1(e.target.value)}
+
+            />
+            <input
+                type="text"
+                id="pubkey2"
+                placeholder="Enter public key 2"
+                style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
+                onChange={(e) => setPubKey2(e.target.value)}
+
+            />
+            <button
+                style={{
+                    backgroundColor: 'red',
+                    color: 'white',
+                    padding: '10px 20px',
+                    borderRadius: '5px',
+                    border: 'none',
+                    marginRight: '5px',
+                }}
+                onClick={() => {
+                    if (pubKey1 && pubKey2) {
+                        setAggregatedPubKey(bufferToHex(bls.aggregatePublicKeys([pubKey1, pubKey2])));
+                        setShowAggregatedPubKey(true);
+                    }
+                }}>
+                Aggregate Public Keys
+            </button>
+
+            {showAggregatedPubKey && (
+                <>
+                    <p>Aggregated Public Key:</p>
+                    <p style={{ overflowWrap: 'break-word', wordBreak: 'break-all' }}>{aggregatedPubKey}</p>
+                </>
+            )}
+        </div>
+    )
+}
+export const VerifyAggregateSignatureButton: React.FC = () => {
+    const [pubKey, setPubKey] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [signature, setSignature] = useState<string | null>(null);
+    const [signatureResult, setSignatureResult] = useState<boolean | null>(null);
+
+    return(
+        <div style={{ textAlign: 'center' }}>
+        <p>🔑Aggregated Public Key</p>
+        <input type="text" id="publickey" placeholder="Enter aggregated public key to verify with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPubKey(e.target.value)}/>
+        <br />
+        <p>🔏Aggregated Signature</p>
+        <input type="text" id="signature" placeholder="Enter aggregated signature to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setSignature(e.target.value)}/>
+        <br />
+        <p>📝Message</p>
+        <input type="text" id="message" placeholder="Enter message to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage(e.target.value)}/>
+        <br />
+        <button
+            className="btn btn-primary"
+            style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
+            onClick={() => {
+                if (signature && pubKey && message) {
+                    checkSig(signature, pubKey, message).then((res) => {
+                        console.log(res)
+                        if (res) {
+                            setSignatureResult(res);
+                        } else {
+                            setSignatureResult(false);
+                        }
+                    });
+                }
+            }}
+        >
+            Verify
+        </button>
+
+        {signatureResult !== null && (
+            <>
+                <p>Signature Result:</p>
+                <p>{signatureResult ? 'Aggregated Signature valid! The Aggregated Signature of the Message was created with the Secret Key that corresponds to the provided Public Key.' : 'Signature invalid! Double check your inputs are correct'}</p>
+            </>
+        )}
+    </div>
+    )
+}
+

--- a/components/multiSignatureSchemes.tsx
+++ b/components/multiSignatureSchemes.tsx
@@ -318,7 +318,6 @@ export const VerifyAggregateSignatureButton: React.FC = () => {
             onClick={() => {
                 if (signature && pubKey && message) {
                     checkSig(signature, pubKey, message).then((res) => {
-                        console.log(res)
                         if (res) {
                             setSignatureResult(res);
                         } else {

--- a/components/signatureSchemes.tsx
+++ b/components/signatureSchemes.tsx
@@ -1,6 +1,11 @@
 "use client";
 const bls = require("@noble/bls12-381");
 import React, { useState } from 'react';
+import {
+    CodeBlock, Pre
+  } from 'fumadocs-ui/components/codeblock';
+import { buttonVariants } from './ui/button';
+import { Input } from './ui/input';
 
 const bufferToHex = (buffer: ArrayBufferLike): string => {
     return [...new Uint8Array(buffer)]
@@ -31,37 +36,18 @@ export const GenerateKeysButton: React.FC = () => {
     };
 
     return (
-        <div style={{ textAlign: 'center' }}>
-            <button
-                className="btn btn-primary"
-                style={{
-                    backgroundColor: 'red',
-                    color: 'white',
-                    padding: '10px 20px',
-                    borderRadius: '5px',
-                    margin: '10px'
-                }}
-                onClick={generateKeys}
-            >
+        <div>
+            <button className={buttonVariants()} onClick={generateKeys}>
                 Generate Keys
             </button>
 
-            <div style={{padding: '10px' }}>
-                <p>🗝️Private Key: {privKey}</p>
-                <button
-                    onClick={() => copyToClipboard(privKey ? String(privKey) : '')}
-                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
-                >
-                    Copy Private Key
-                </button>
-                <p style={{overflowWrap: 'break-word' }}>🔑Public Key: {pubKey}</p>
-                <button
-                    onClick={() => copyToClipboard(pubKey ? String(pubKey) : '')}
-                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
-                >
-                    Copy Public Key
-                </button>
-            </div>
+            {privKey && <CodeBlock title="🗝️ Private Key" lang="bash" allowCopy={true}>
+                <Pre>{privKey}</Pre>
+            </CodeBlock>}
+
+            {pubKey && <CodeBlock title="🔑 Public Key:" lang="bash" allowCopy={true}>
+                <Pre>{pubKey}</Pre>
+            </CodeBlock>}
         </div>
     );
 }
@@ -71,38 +57,29 @@ export const SignMessageButton: React.FC = () => {
     const [privKey, setPrivKey] = useState<string | null>(null);
     const [message, setMessage] = useState<string | null>(null);
     const [signature, setSignature] = useState<string | null>(null);
-    const [showSignature, setShowSignature] = useState(false);
 
     const signMessage = async () => {
         if (!privKey || !message) {
             return;
         }
         setSignature(bufferToHex(await bls.sign(new TextEncoder().encode(message), privKey)));
-        setShowSignature(true);
     }
 
     return (
-        <div style={{ textAlign: 'center' }}>
+        <div>
             <p>🗝️Private Key</p>
-            <input type="text" id="privatekey" placeholder="Enter private key to sign message with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPrivKey(e.target.value)} />
+            <Input id="privatekey" placeholder="Enter private key to sign message with" onChange={(e) => setPrivKey(e.target.value)} />
             <br />
             <p>📝Message</p>
-            <input type="text" id="message" placeholder="Enter message to sign" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage(e.target.value)} />
+            <Input id="message" placeholder="Enter message to sign" onChange={(e) => setMessage(e.target.value)} />
 
-            <button
-                className="btn btn-primary"
-                style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
-                onClick={signMessage}
-            >
+            <button className={buttonVariants()} onClick={signMessage} disabled={!privKey || !message}>
                 Sign Message
             </button>
 
-            {showSignature && (
-                <>
-                    <p>Signature:</p>
-                    <p style={{ overflowWrap: 'break-word' }}>{signature}</p>
-                </>
-            )}
+            {signature && <CodeBlock title="🔏 Signature:" lang="bash" allowCopy={true}>
+                <Pre>{signature}</Pre>
+            </CodeBlock>}
         </div>
     );
 }
@@ -112,44 +89,40 @@ export const VerifySignatureButton: React.FC = () => {
     const [pubKey, setPubKey] = useState<string | null>(null);
     const [message, setMessage] = useState<string | null>(null);
     const [signature, setSignature] = useState<string | null>(null);
-    const [signatureResult, setSignatureResult] = useState<boolean | null>(null);
+    const [isValid, setIsValid] = useState<boolean | null>(null);
+
+    const verifySignature = async () => {
+        if (signature && pubKey && message) {
+            checkSig(signature, pubKey, message).then((res) => {
+                console.log(res)
+                if (res) {
+                    setIsValid(res);
+                } else {
+                    setIsValid(false);
+                }
+            });
+        }
+    };
 
     return (
-        <div style={{ textAlign: 'center' }}>
+        <div>
             <p>🔑Public Key</p>
-            <input type="text" id="publickey" placeholder="Enter public key to verify signature with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPubKey(e.target.value)}/>
+            <Input id="publickey" placeholder="Enter public key to verify signature" onChange={(e) => setPubKey(e.target.value)} />
             <br />
             <p>📝Message</p>
-            <input type="text" id="message" placeholder="Enter message to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage(e.target.value)}/>
+            <Input id="message" placeholder="Enter message to verify" onChange={(e) => setMessage(e.target.value)} />
             <br />
             <p>🔏Signature</p>
-            <input type="text" id="signature" placeholder="Enter signature to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setSignature(e.target.value)}/>
-            <br />
-            <button
-                className="btn btn-primary"
-                style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
-                onClick={() => {
-                    if (signature && pubKey && message) {
-                        checkSig(signature, pubKey, message).then((res) => {
-                            if (res) {
-                                setSignatureResult(res);
-                            } else {
-                                setSignatureResult(false);
-                            }
-                        });
-                    }
-                }}
-            >
+            <Input id="signature" placeholder="Enter signature to verify" onChange={(e) => setSignature(e.target.value)} />
+
+            <button className={buttonVariants()} onClick={verifySignature} disabled={!signature || !pubKey || !message}>
                 Verify Signature
             </button>
 
-            {signatureResult !== null && (
-                <>
-                    <p>Signature Result:</p>
-                    <p>{signatureResult ? 'Signature valid! The Signature of the Message was created with the Secret Key that corresponds to the provided Public Key.' : 'Signature invalid! Double check your inputs are correct'}</p>
-                </>
+            {isValid !== null && (
+                <p>{isValid ? '✅ Signature is valid!' : '❌ Signature is invalid!'}</p>
             )}
         </div>
-    )
+    );
 }
 

--- a/components/signatureSchemes.tsx
+++ b/components/signatureSchemes.tsx
@@ -131,7 +131,6 @@ export const VerifySignatureButton: React.FC = () => {
                 onClick={() => {
                     if (signature && pubKey && message) {
                         checkSig(signature, pubKey, message).then((res) => {
-                            console.log(res)
                             if (res) {
                                 setSignatureResult(res);
                             } else {

--- a/components/signatureSchemes.tsx
+++ b/components/signatureSchemes.tsx
@@ -1,0 +1,156 @@
+"use client";
+const bls = require("@noble/bls12-381");
+import React, { useState } from 'react';
+
+const bufferToHex = (buffer: ArrayBufferLike): string => {
+    return [...new Uint8Array(buffer)]
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+}
+
+const checkSig = async (signature: string, publicKey: string, message: string) => {
+    let res = await bls.verify(signature, new TextEncoder().encode(message), publicKey);
+    return res
+}
+
+export const GenerateKeysButton: React.FC = () => {
+
+    const [privKey, setPrivKey] = useState<string | null>(null);
+    const [pubKey, setPubKey] = useState<string | null>(null);
+    const generateKeys = () => {
+        const privKey = new Uint8Array(32);
+        crypto.getRandomValues(privKey);
+        const pubKey = bufferToHex(bls.getPublicKey(privKey));
+        setPrivKey(bufferToHex(privKey));
+        setPubKey(pubKey);
+        return { privKey, pubKey };
+    };
+
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text);
+    };
+
+    return (
+        <div style={{ textAlign: 'center' }}>
+            <button
+                className="btn btn-primary"
+                style={{
+                    backgroundColor: 'red',
+                    color: 'white',
+                    padding: '10px 20px',
+                    borderRadius: '5px',
+                    margin: '10px'
+                }}
+                onClick={generateKeys}
+            >
+                Generate Keys
+            </button>
+
+            <div style={{padding: '10px' }}>
+                <p>🗝️Private Key: {privKey}</p>
+                <button
+                    onClick={() => copyToClipboard(privKey ? String(privKey) : '')}
+                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
+                >
+                    Copy Private Key
+                </button>
+                <p style={{overflowWrap: 'break-word' }}>🔑Public Key: {pubKey}</p>
+                <button
+                    onClick={() => copyToClipboard(pubKey ? String(pubKey) : '')}
+                    style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', border: 'none', marginRight: '5px' }}
+                >
+                    Copy Public Key
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export const SignMessageButton: React.FC = () => {
+
+    const [privKey, setPrivKey] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [signature, setSignature] = useState<string | null>(null);
+    const [showSignature, setShowSignature] = useState(false);
+
+    const signMessage = async () => {
+        if (!privKey || !message) {
+            return;
+        }
+        setSignature(bufferToHex(await bls.sign(new TextEncoder().encode(message), privKey)));
+        setShowSignature(true);
+    }
+
+    return (
+        <div style={{ textAlign: 'center' }}>
+            <p>🗝️Private Key</p>
+            <input type="text" id="privatekey" placeholder="Enter private key to sign message with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPrivKey(e.target.value)} />
+            <br />
+            <p>📝Message</p>
+            <input type="text" id="message" placeholder="Enter message to sign" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage(e.target.value)} />
+
+            <button
+                className="btn btn-primary"
+                style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
+                onClick={signMessage}
+            >
+                Sign Message
+            </button>
+
+            {showSignature && (
+                <>
+                    <p>Signature:</p>
+                    <p style={{ overflowWrap: 'break-word' }}>{signature}</p>
+                </>
+            )}
+        </div>
+    );
+}
+
+export const VerifySignatureButton: React.FC = () => {
+
+    const [pubKey, setPubKey] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [signature, setSignature] = useState<string | null>(null);
+    const [signatureResult, setSignatureResult] = useState<boolean | null>(null);
+
+    return (
+        <div style={{ textAlign: 'center' }}>
+            <p>🔑Public Key</p>
+            <input type="text" id="publickey" placeholder="Enter public key to verify signature with" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setPubKey(e.target.value)}/>
+            <br />
+            <p>📝Message</p>
+            <input type="text" id="message" placeholder="Enter message to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setMessage(e.target.value)}/>
+            <br />
+            <p>🔏Signature</p>
+            <input type="text" id="signature" placeholder="Enter signature to verify" style={{ width: '100%', padding: '10px', marginBottom: '10px' }} onChange={(e) => setSignature(e.target.value)}/>
+            <br />
+            <button
+                className="btn btn-primary"
+                style={{ backgroundColor: 'red', color: 'white', padding: '10px 20px', borderRadius: '5px', margin: '10px' }}
+                onClick={() => {
+                    if (signature && pubKey && message) {
+                        checkSig(signature, pubKey, message).then((res) => {
+                            console.log(res)
+                            if (res) {
+                                setSignatureResult(res);
+                            } else {
+                                setSignatureResult(false);
+                            }
+                        });
+                    }
+                }}
+            >
+                Verify Signature
+            </button>
+
+            {signatureResult !== null && (
+                <>
+                    <p>Signature Result:</p>
+                    <p>{signatureResult ? 'Signature valid! The Signature of the Message was created with the Secret Key that corresponds to the provided Public Key.' : 'Signature invalid! Double check your inputs are correct'}</p>
+                </>
+            )}
+        </div>
+    )
+}
+

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,11 @@
+export const Input: React.FC<{ id: string, placeholder: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void }> = ({ id, placeholder, onChange }) => {
+    return (
+        <input
+            type="text"
+            id={id}
+            placeholder={placeholder}
+            style={{ width: '100%', padding: '10px', marginBottom: '10px' }}
+            onChange={onChange}
+        />
+    );
+};

--- a/content/common/cryptography/multi-signature-schemes-demo.mdx
+++ b/content/common/cryptography/multi-signature-schemes-demo.mdx
@@ -1,13 +1,37 @@
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/utils/cn';
+import {GenerateKeysButton, SignMessageButton, AggregateSignaturesButton, AggregatePublicKeysButton, VerifyAggregateSignatureButton} from '@/components/multiSignatureSchemes';
 
-Check out this assignment
+Let's explore the use of a Multi-Signature Scheme. We'll take the following steps:
 
-<a
-    href="https://ava-labs.github.io/academy-bls-aggregation-demo/#/multi"
-    target='_blank'
-    className={cn(buttonVariants({ size: 'lg' }))}
->
-    Open the Demo
-</a>
+- **Generate Two Key Pairs**: We will generate two key pairs.
+- **Sign Message**: We create two Signatures of the same Message with the two Secret Keys.
+- **Aggregate Signatures**: We aggregate the two Signatures to a single Signature.
+- **Aggregate Public Keys**: We aggregate the two Public Keys to a single Public Key.
+- **Verify aggregated Signature**: We verify the Signature with the aggregated Public Key.
+
+## Generate Keys
+Start by generating two Key Pairs each consisting of a Public and Secret Key. In a real-world setting these key pairs would be created by independent actors, but for the sake of the exercise we will play multiple actors here.
+<GenerateKeysButton />
+
+## Sign
+Now use the generated Secret Keys to sign a Message. Make sure to pick exactly the same Message for both Signatures, e.g. "Per consensum ad astra".
+
+<SignMessageButton />
+
+## Aggregate Signatures
+We can now utilize the signature aggregation to create an aggregated Signature. In this exercise we are only aggregating two signatures, but we could do this with hundreds or thousands. Side fact: It does not matter in which order the signatures are aggrated.
+<AggregateSignaturesButton />
+
+## Aggregate Public Keys
+To verify an aggregated Signature, we need also need to aggregate the Public Keys that correspond to the Private Keys that were used to sign the message. Analogous to the signatures we can aggregate many more than just two Public Keys and also here the order does not matter.
+
+<AggregatePublicKeysButton />
+
+## Verify
+Anyone, that has access to the aggregated Public Key can now verify the Signature of the Message. Therefore, the Authenticity, Non-Repudiation and Integrity of the Message can be trusted in an efficient for a large number of signers.
+
+<VerifyAggregateSignatureButton />
+
+
+## Conclusion
+Congrats to going through the exercise and experiencing hands-on how we can utilize Siganture Aggregation. You will see in the next chapter about Avalanche Warp Messaging how Mutli-Signature schemes can enable secure and efficient cross-Subnet communication.
 

--- a/content/common/cryptography/signature-schemes-demo.mdx
+++ b/content/common/cryptography/signature-schemes-demo.mdx
@@ -1,12 +1,44 @@
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/utils/cn';
+import { bls } from '@noble/bls12-381'
 
-Check out this assignment
+
+
+
+# Using a Signature Scheme
+
+Let's get our hands dirty and use a signature scheme. We'll take the following steps:
+
+- **Generate Key Pair**: We will generate a key pair consisting of a Public and a Secret Key.
+- **Sign Message**: We create a Signature by signing the Message with the Secret Key.
+- **Verify Signature**: We verify the Signature of a Message with the Public Key.
+
+# Generate Keys
+Start by generating a Key Pair consisting of a Public and a Secret Key.
 
 <a
-    href="https://ava-labs.github.io/academy-bls-aggregation-demo/"
     target='_blank'
     className={cn(buttonVariants({ size: 'lg' }))}
 >
-    Open the Demo
+    Generate Keys
 </a>
+
+# Sign
+Now use the generated Secret Key to sign a Message. Pick any message you want to sign, e.g. "Per consensum ad astra".
+
+🗝️Secret Key
+<input name="secretkey" style={{ marginBottom: '10px' }} />
+<br />
+📝Message
+<input name="message" style={{ marginBottom: '10px' }} />
+
+# Verify
+Anyone, that has access to your Public Key corresponding to the Private Key used for signing the message can now verify the signature of the Message. Therefore, the Authenticity, Non-Repudiation and Integrity of the Message can be trusted.
+
+🔑Public Key
+<input name="pubkey" style={{ marginBottom: '10px' }} />
+<br />
+🖋️Signature
+<input name="signature" style={{ marginBottom: '10px' }} />
+📝Message
+<input name="message" style={{ marginBottom: '10px' }} />

--- a/content/common/cryptography/signature-schemes-demo.mdx
+++ b/content/common/cryptography/signature-schemes-demo.mdx
@@ -1,11 +1,4 @@
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/utils/cn';
-import { bls } from '@noble/bls12-381'
-
-
-
-
-# Using a Signature Scheme
+import { GenerateKeysButton, SignMessageButton, VerifySignatureButton } from '@/components/signatureSchemes'
 
 Let's get our hands dirty and use a signature scheme. We'll take the following steps:
 
@@ -13,32 +6,17 @@ Let's get our hands dirty and use a signature scheme. We'll take the following s
 - **Sign Message**: We create a Signature by signing the Message with the Secret Key.
 - **Verify Signature**: We verify the Signature of a Message with the Public Key.
 
-# Generate Keys
+## Generate Keys
 Start by generating a Key Pair consisting of a Public and a Secret Key.
 
-<a
-    target='_blank'
-    className={cn(buttonVariants({ size: 'lg' }))}
->
-    Generate Keys
-</a>
+<GenerateKeysButton />
 
-# Sign
+## Sign
 Now use the generated Secret Key to sign a Message. Pick any message you want to sign, e.g. "Per consensum ad astra".
 
-🗝️Secret Key
-<input name="secretkey" style={{ marginBottom: '10px' }} />
-<br />
-📝Message
-<input name="message" style={{ marginBottom: '10px' }} />
+<SignMessageButton />
 
-# Verify
+## Verify
 Anyone, that has access to your Public Key corresponding to the Private Key used for signing the message can now verify the signature of the Message. Therefore, the Authenticity, Non-Repudiation and Integrity of the Message can be trusted.
 
-🔑Public Key
-<input name="pubkey" style={{ marginBottom: '10px' }} />
-<br />
-🖋️Signature
-<input name="signature" style={{ marginBottom: '10px' }} />
-📝Message
-<input name="message" style={{ marginBottom: '10px' }} />
+<VerifySignatureButton />

--- a/content/course/interchain-messaging/08-securing-cross-chain-communication/03-use-a-signature-scheme.mdx
+++ b/content/course/interchain-messaging/08-securing-cross-chain-communication/03-use-a-signature-scheme.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use a Signature Scheme
-description: TBD
+description: Learn how to use a signature scheme to secure cross-chain communication.
 updated: 2024-05-31
 authors: [martineckardt]
 icon: Terminal

--- a/content/course/interchain-messaging/08-securing-cross-chain-communication/06-use-a-multi-signature-scheme.mdx
+++ b/content/course/interchain-messaging/08-securing-cross-chain-communication/06-use-a-multi-signature-scheme.mdx
@@ -6,6 +6,6 @@ authors: [martineckardt]
 icon: Terminal
 ---
 
-import SignatureSchemesDemo from "@/content/common/cryptography/signature-schemes-demo.mdx"
+import SignatureSchemesDemo from "@/content/common/cryptography/multi-signature-schemes-demo.mdx"
 
 <SignatureSchemesDemo />

--- a/content/course/interchain-messaging/08-securing-cross-chain-communication/06-use-a-multi-signature-scheme.mdx
+++ b/content/course/interchain-messaging/08-securing-cross-chain-communication/06-use-a-multi-signature-scheme.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use a Multi-Signature Scheme
-description: TBD
+description: Learn how to use multi-signature schemes to secure cross-chain communication.
 updated: 2024-05-31
 authors: [martineckardt]
 icon: Terminal

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@headlessui/react": "^2.1.2",
     "@heroicons/react": "^2.1.5",
     "@icons-pack/react-simple-icons": "^10.0.0",
+    "@noble/bls12-381": "^1.4.0",
     "@vercel/analytics": "^1.3.1",
     "@vercel/speed-insights": "^1.0.12",
     "fumadocs-core": "12.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,6 +200,11 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.6.tgz#6b63a7b4ff3b7b410a038e3ee839c951a3136dc9"
   integrity sha512-NANtw+ead1rSDK1jxmzq3TYkl03UNK2KHqUYf1nIhNci6NkeqBD4s1njSzYGIlSHxCK+wSaL8RXZm4v+NF/pMw==
 
+"@noble/bls12-381@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/bls12-381/-/bls12-381-1.4.0.tgz#4db0e1577ef85632347e86eee81062acdda6d65b"
+  integrity sha512-mIYqC2jMX7Lcu1QtU/FFftMPDSXNCdlGex6BSf5nPojHjnzzBgs1klFWpB1R8YjqHmOO9xrCzF19f2c42+z3vg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2758,7 +2763,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2784,7 +2798,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
In the ICM course there is a [chapter about Cryptography](https://academy.avax.network/course/interchain-messaging/08-securing-cross-chain-communication/01-securing-cross-chain-communication) basics that links to two external demo:

[Signature Schemes](https://ava-labs.github.io/academy-bls-aggregation-demo/#/)
[Multi-Signature Schemes](https://ava-labs.github.io/academy-bls-aggregation-demo/#/multi)
These demos are built with VueJS. Instead of linking out, we should reimplement them with React into the chapter directly.