### PR TITLE
create: new search route to index guides too

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,11 +1,20 @@
-import { getPages } from '@/utils/source';
+import { getCoursePages } from '@/utils/course-loader';
+import { getGuidePages } from '@/utils/guide-loader';
 import { createSearchAPI } from 'fumadocs-core/search/server';
 
 export const { GET } = createSearchAPI('advanced', {
-  indexes: getPages().map((page) => ({
-    title: page.data.title,
-    structuredData: page.data.exports.structuredData,
-    id: page.url,
-    url: page.url,
-  })),
+  indexes: [
+    ...getCoursePages().map((page) => ({
+      title: page.data.title,
+      structuredData: page.data.exports.structuredData,
+      id: page.url,
+      url: page.url,
+    })),
+    ...getGuidePages().map((page) => ({
+      title: page.data.title,
+      structuredData: page.data.exports.structuredData,
+      id: page.url,
+      url: page.url,
+    })),
+  ],
 });

--- a/app/course/[[...slug]]/page.tsx
+++ b/app/course/[[...slug]]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { DocsPage, DocsBody } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
-import { getPage, getPages, type Page } from '@/utils/source';
+import { getCoursePage, getCoursePages, type Page } from '@/utils/course-loader';
 import { createMetadata } from '@/utils/metadata';
 import IndexedDBComponent from '@/components/tracker'
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -33,7 +33,7 @@ export default function Page({
 }: {
   params: Param;
 }): React.ReactElement {
-  const page = getPage(params.slug);
+  const page = getCoursePage(params.slug);
 
   if (!page) notFound();
 
@@ -105,7 +105,7 @@ export default function Page({
 }
 
 function Category({ page }: { page: Page }): React.ReactElement {
-  const filtered = getPages()
+  const filtered = getCoursePages()
     .filter(
       (item) =>
         item.file.dirname === page.file.dirname && item.file.name !== 'index',
@@ -126,7 +126,7 @@ function Category({ page }: { page: Page }): React.ReactElement {
 }
 
 export function generateMetadata({ params }: { params: Param }): Metadata {
-  const page = getPage(params.slug);
+  const page = getCoursePage(params.slug);
 
   if (!page) notFound();
 
@@ -158,7 +158,7 @@ export function generateMetadata({ params }: { params: Param }): Metadata {
 }
 
 export function generateStaticParams(): Param[] {
-  return getPages().map<Param>((page) => ({
+  return getCoursePages().map<Param>((page) => ({
     slug: page.slugs,
   }));
 }

--- a/app/guide/[slug]/page.tsx
+++ b/app/guide/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
-import { guide } from '@/utils/source';
+import { getGuidePage, getGuidePages } from '@/utils/guide-loader';
 import { createMetadata } from '@/utils/metadata';
 import { buttonVariants } from '@/components/ui/button';
 import { ArrowUpRightIcon, MessagesSquare } from 'lucide-react';
@@ -21,7 +21,7 @@ export default function Page({
 }: {
     params: Param;
 }): React.ReactElement {
-    const page = guide.getPage([params.slug]);
+    const page = getGuidePage([params.slug]);
 
     if (!page) notFound();
 
@@ -114,7 +114,7 @@ export default function Page({
 }
 
 export function generateMetadata({ params }: { params: Param }): Metadata {
-  const page = guide.getPage([params.slug]);
+  const page = getGuidePage([params.slug]);
 
   if (!page) notFound();
 
@@ -147,7 +147,7 @@ export function generateMetadata({ params }: { params: Param }): Metadata {
 
 
 export function generateStaticParams(): Param[] {
-    return guide.getPages().map<Param>((page) => ({
+    return getGuidePages().map<Param>((page) => ({
         slug: page.slugs[0],
     }));
 }

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link';
-import { guide } from '@/utils/source';
+import { getGuidePages } from '@/utils/guide-loader';
 import { buttonVariants } from '@/components/ui/button';
 import { SiX } from '@icons-pack/react-simple-icons';
 
 export default function Page(): React.ReactElement {
-    const guides = [...guide.getPages()].sort(
+    const guides = [...getGuidePages()].sort(
         (a, b) =>
             new Date(b.data.date ?? b.file.name).getTime() -
             new Date(a.data.date ?? a.file.name).getTime(),

--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -1,5 +1,5 @@
 import { type BaseLayoutProps, type DocsLayoutProps } from 'fumadocs-ui/layout';
-import { pageTree } from '@/utils/source';
+import { coursePageTree } from '@/utils/course-loader';
 import { RootToggle } from 'fumadocs-ui/components/layout/root-toggle';
 import { Title } from '@/app/layout.client';
 import { MailIcon, SquareStackIcon, ArrowLeftRight, SquareIcon, SquareCode, Triangle } from 'lucide-react';
@@ -31,7 +31,7 @@ export const baseOptions: BaseLayoutProps = {
 
 export const docsOptions: DocsLayoutProps = {
   ...baseOptions,
-  tree: pageTree,
+  tree: coursePageTree,
   sidebar: {
     defaultOpenLevel: 0,
     banner: (

--- a/utils/course-loader.ts
+++ b/utils/course-loader.ts
@@ -1,0 +1,39 @@
+import { createMDXSource, defaultSchemas } from 'fumadocs-mdx';
+import { z } from 'zod';
+import type { InferMetaType, InferPageType } from 'fumadocs-core/source';
+import { loader } from 'fumadocs-core/source';
+import { icons } from 'lucide-react';
+import { map } from '.map';
+import { create } from '@/components/ui/icon';
+
+const loaderOutput = loader({
+  baseUrl: '/course',
+  rootDir: 'course',
+  icon(icon) {
+    if (icon && icon in icons)
+      return create({ icon: icons[icon as keyof typeof icons] });
+  },
+  source: createMDXSource(map, {
+    schema: {
+      frontmatter: defaultSchemas.frontmatter.extend({
+        preview: z.string().optional(),
+        toc: z.boolean().default(true),
+        index: z.boolean().default(false),
+        updated: z.string().or(z.date()).transform((value, context) => {
+            try {
+              return new Date(value);
+            } catch {
+              context.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid date" });
+              return z.NEVER;
+            }
+          }),
+        authors: z.array(z.string()),
+        comments: z.boolean().default(false),
+      }),
+    },
+  }),
+});
+
+export type Page = InferPageType<typeof loaderOutput>;
+export type Meta = InferMetaType<typeof loaderOutput>;
+export const { getPage: getCoursePage, getPages: getCoursePages, pageTree: coursePageTree } = loaderOutput;

--- a/utils/guide-loader.ts
+++ b/utils/guide-loader.ts
@@ -1,0 +1,24 @@
+import { createMDXSource, defaultSchemas } from 'fumadocs-mdx';
+import { z } from 'zod';
+import type { InferMetaType, InferPageType } from 'fumadocs-core/source';
+import { loader } from 'fumadocs-core/source';
+import { map } from '.map';
+
+const loaderOutput = loader({
+  baseUrl: '/guide',
+  rootDir: 'guide',
+  source: createMDXSource(map, {
+    schema: {
+      frontmatter: defaultSchemas.frontmatter.extend({
+        authors: z.array(z.string()),
+        topics: z.array(z.string()),
+        date: z.string().date().or(z.date()).optional(),
+        comments: z.boolean().default(false),
+      }),
+    },
+  }),
+});
+
+export type Page = InferPageType<typeof loaderOutput>;
+export type Meta = InferMetaType<typeof loaderOutput>;
+export const { getPage: getGuidePage, getPages: getGuidePages, pageTree: guidePageTree } = loaderOutput;


### PR DESCRIPTION
this PR creates separate loaders for course pages and guides, also makes sure the guide pages are now visible in search results