### PR TITLE
fix typo at Update 04-relayer-configuration.mdx

### DIFF
--- a/content/course/interchain-messaging/10-running-a-relayer/04-relayer-configuration.mdx
+++ b/content/course/interchain-messaging/10-running-a-relayer/04-relayer-configuration.mdx
@@ -92,7 +92,7 @@ Next is the configuration for our source blockchain. This is the configuration o
 - **vm:** A string specifying the virtual machine of the destination L1's blockchain. Currently, only the EVM is supported, but this field has been added in anticipation of communication between blockchains powered by different virtual machines in the future.
 - **rpc-endpoint:** An API Config containing:
 <div class="pl-6">
-- **base-url:** RPC endpoint of the destination L1's API node.
+- **base-url:** RPC endpoint of the source L1's API node.
 - **query-parameters:** Additional query parameters to include in the API requests
 - **http-headers:** Additional HTTP headers to include in the API requests
 </div>


### PR DESCRIPTION
In the first setting (source-blockchains), the base-url is actually about the source chain.