### PR TITLE
Update 03-transfer-native-tokens.mdx

### DIFF
--- a/content/course/interchain-token-transfer/03-tokens/03-transfer-native-tokens.mdx
+++ b/content/course/interchain-token-transfer/03-tokens/03-transfer-native-tokens.mdx
@@ -37,7 +37,7 @@ export MYADDRESS=0x...
 
 ### Check the Balance
 
-Now we are checking the balance of that key on 
+Now we are checking the balance of that key on (don't forget to replace `myblockchain` with `local-c` if you’re working on a local network, as in earlier chapters)
 
 ```bash
 cast balance $MYADDRESS --rpc-url myblockchain


### PR DESCRIPTION
Using the same name for both the RPC URL and the Blockchain could confuse learners. A warning about this could be quite helpful.