### PR TITLE
Add Note on why L1s must sync the P-Chain

### DIFF
--- a/content/guide/subnet-vs-l1-validators.mdx
+++ b/content/guide/subnet-vs-l1-validators.mdx
@@ -45,6 +45,8 @@ L1 validators are required to:
 - Sync and validate a specific L1
 - Sync the latest P-Chain state
 
+Syncing the P-Chain state is required for basic L1 functionality. It enables the L1 to track its validator weights so that it can perform consensus and validate ICM messages from other L1s, including the P-Chain.
+
 L1 validators do not need to:
 - Stake 2,000 AVAX
 - Validate or participate in consensus on the Primary Network (X, P, and C-Chains)


### PR DESCRIPTION
small addition to the guide on Subnet vs. L1 validators

https://avalanche-academy-git-l1-validator-ava-labs.vercel.app/guide/subnet-vs-l1-validators