### PR TITLE
Add Context

### DIFF
--- a/content/guide/subnet-vs-l1-validators.mdx
+++ b/content/guide/subnet-vs-l1-validators.mdx
@@ -52,3 +52,6 @@ L1 validators do not need to:
 - Validate or participate in consensus on the Primary Network (X, P, and C-Chains)
 
 Unless removed by the Owner Key, any Subnet validator added to the network before `ConvertSubnetToL1Tx` will continue to validate the network until its "end time" is reached.
+
+Once a Subnet has been converted to an L1, Subnet validators can no longer be added. After a previous Subnet validator is removed or its "end time" is reached, a validator with
+the name NodeID can be added as an L1 validator to the network with `RegisterL1ValidatorTx`, the same as any other L1 validator who wishes to join the network.


### PR DESCRIPTION
Q: After expiration of the current Subnet validation, can the Subnet validators continue/restake their validation without switching to L1 validation? If not, how do Subnet validators switch to L1 validation now they have expired?

A: In short: No, once a Subnet has been converted to an L1, Subnet validators can no longer be added. A validator would be able to rejoin the network as an L1 validator by interacting with the Validator Manager contract just as all other validators in the network would if they want to join.